### PR TITLE
Return undefined for undefined promise resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/standard-promise",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Standardize Node Promise return values",
   "main": "src/StandardPromise.js",
   "scripts": {

--- a/src/StandardPromise.js
+++ b/src/StandardPromise.js
@@ -28,16 +28,14 @@ const promisify = function(promise) {
 			if (StandardPromise.isSP(data)) {
 				return data;
 			}
-			return data !== undefined
-			            ? StandardPromise.build(undefined, data)
-			            : StandardPromise.build(StandardError[204]);
+			return StandardPromise.build(undefined, data);
 		}).catch((err) => {
 			return Promise.resolve(
 				err !== undefined
 				    ? StandardPromise.build(err)
 				    : StandardPromise.build(StandardError.StandardPromise_502)
 			);
-		});;
+		});
 	} catch(err) {
 		CBLogger.error('promise_resolution_error', {message: 'Unexpected error thrown while trying to resolve a Promise in StandardPromise'}, {}, err);
 		return Promise.resolve(StandardPromise.build(err));

--- a/test/StandardPromise.test.js
+++ b/test/StandardPromise.test.js
@@ -98,7 +98,7 @@ test('Same as above but reject the promises', async() => {
 	expect(sp5.data).toBe(undefined);
 });
 
-test('Resolving a StandardPromise with undefined value stores 204 StandardError in err attribute', async() => {
+test('Can resolve a StandardPromise with undefined', async() => {
 	// Setup
 	var p = new Promise(async(resolve, reject) => {
 		setTimeout(() => {resolve()}, 1);
@@ -112,9 +112,9 @@ test('Resolving a StandardPromise with undefined value stores 204 StandardError 
 	var sp2 = await _(p2);
 
 	// Test
-	expect(sp.err).toBe(StandardError[204]);
+	expect(sp.err).toBe(undefined);
 	expect(sp.data).toBe(undefined);
-	expect(sp2.err).toBe(StandardError[204]);
+	expect(sp2.err).toBe(undefined);
 	expect(sp2.data).toBe(undefined);
 });
 


### PR DESCRIPTION
- Update to return `undefined` in `data` and `error` fields when a StandardPromise is resolved with `undefined`. Previously was returning a StandardError value explicitly stating what happened, but that was more confusing than not.
- Bump version to 0.0.2